### PR TITLE
Make main attribute understood by bower for automatic file inclusion

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "probalazs <probalazs@nyenyere.eu>"
   ],
   "description": "jquery kanb directive",
-  "main": "./src/angular-knob.js",
+  "main": "src/angular-knob.js",
   "keywords": [
     "jquery",
     "kanb",


### PR DESCRIPTION
Hi yunlzheng,

This adjustment will help tools that can automatically include your file as a library if the main attribute can be parsed. It is looking for a path relative to your project root.