### PR TITLE
修正 双向绑定事，数值抖动的问题 

### DIFF
--- a/src/angular-knob.js
+++ b/src/angular-knob.js
@@ -1,31 +1,33 @@
-angular.module('ui.knob', []).directive('knob', ['$timeout', function($timeout) {
-    'use strict';
+angular.module('ui.knob', []).directive('knob', ['$timeout', function ($timeout) {
+  'use strict';
 
-    return {
-        restrict: 'EA',
-        replace: true,
-        template: '<input value="{{ knobData }}"/>',
-        scope: {
-            knobData: '=',
-            knobOptions: '&'
-        },
-        link: function($scope, $element) {
-            var knobInit = $scope.knobOptions() || {};
+  return {
+    restrict: 'EA',
+    replace: true,
+    template: '<input value="{{ knobData }}"/>',
+    scope: {
+      knobData: '=',
+      knobOptions: '&'
+    },
+    link: function ($scope, $element) {
+      var knobInit = $scope.knobOptions() || {};
+      var _value;
 
-            knobInit.release = function(newValue) {
-                $timeout(function() {
-                    $scope.knobData = newValue;
-                    $scope.$apply();
-                });
-            };
+      knobInit.release = function (newValue) {
+        $timeout(function () {
+          $scope.knobData = newValue;
+          _value = newValue;
+          //$scope.$apply();
+        });
+      };
 
-            $scope.$watch('knobData', function(newValue, oldValue) {
-                if (newValue != oldValue) {
-                    $($element).val(newValue).change();
-                }
-            });
-
-            $($element).val($scope.knobData).knob(knobInit);
+      $scope.$watch('knobData', function (newValue, oldValue) {
+        if (newValue != oldValue && newValue != _value) {
+          $($element).val(newValue).change();
         }
-    };
+      });
+
+      $($element).val($scope.knobData).knob(knobInit);
+    }
+  };
 }]);

--- a/src/angular-knob.js
+++ b/src/angular-knob.js
@@ -1,33 +1,32 @@
-angular.module('ui.knob', []).directive('knob', ['$timeout', function ($timeout) {
-  'use strict';
+angular.module('ui.knob', []).directive('knob', ['$timeout', function($timeout) {
+    'use strict';
 
-  return {
-    restrict: 'EA',
-    replace: true,
-    template: '<input value="{{ knobData }}"/>',
-    scope: {
-      knobData: '=',
-      knobOptions: '&'
-    },
-    link: function ($scope, $element) {
-      var knobInit = $scope.knobOptions() || {};
-      var _value;
+    return {
+        restrict: 'EA',
+        replace: true,
+        template: '<input value="{{ knobData }}"/>',
+        scope: {
+            knobData: '=',
+            knobOptions: '&'
+        },
+        link: function($scope, $element) {
+            var knobInit = $scope.knobOptions() || {};
+            var _value;
+            knobInit.release = function(newValue) {
+                $timeout(function() {
+                    $scope.knobData = newValue;
+                    _value = newValue;
+                    // $scope.$apply();
+                });
+            };
 
-      knobInit.release = function (newValue) {
-        $timeout(function () {
-          $scope.knobData = newValue;
-          _value = newValue;
-          //$scope.$apply();
-        });
-      };
+            $scope.$watch('knobData', function(newValue, oldValue) {
+                if (newValue != oldValue && newValue != _value) {
+                    $($element).val(newValue).change();
+                }
+            });
 
-      $scope.$watch('knobData', function (newValue, oldValue) {
-        if (newValue != oldValue && newValue != _value) {
-          $($element).val(newValue).change();
+            $($element).val($scope.knobData).knob(knobInit);
         }
-      });
-
-      $($element).val($scope.knobData).knob(knobInit);
-    }
-  };
+    };
 }]);


### PR DESCRIPTION
release 触发value变化，然后更新scope相应的值，此时亦会触发$watch('knobData')，这应该是不必要的，因为watch 是为了在外界改变scope时程序可以相应体现。但是自己改值也会触发的话，就会出现抖动问题。因此在$watch触发后，要先校验newValue是否合刚release触发的值是否相同，若相同，则不处理