### PR TITLE
bump jquery dependency up to latest 2.x

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Angular jQuery Knob demo</title>
-    <script src="../bower_components/jquery/jquery.min.js"></script>
+    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
     <script src="../bower_components/angular/angular.js"></script>
     <script src="../bower_components/jquery-knob/js/jquery.knob.js"></script>
 

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "jquery": "~2.0.3",
+    "jquery": "~2.2.4",
     "jquery-knob": "~1.2.3"
   }
 }


### PR DESCRIPTION
Having angular-knob's jquery dependency be "~2.0.3" means that a project (like mine) that uses a newer 2.x version of jquery will get the following warning when doing a `bower install`:

```
Please note that,
    angular-knob#0.0.3 depends on jquery#~2.0.3 which resolved to jquery#2.0.3
    bootstrap#3.3.6 depends on jquery#1.9.1 - 2 which resolved to jquery#2.2.4
    jquery-knob#1.2.13 depends on jquery#>=1.7.0 which resolved to jquery#3.1.0
Resort to using jquery#2.2.4 which resolved to jquery#2.2.4
Code incompatibilities may occur.
```

It might be even better to change this to something similar to jquery-knob, like ">=2.0.3". 

This is a breaking change (I think..?), because at the very least this means `jquery.min.js` will reside in a different location upon installation.
